### PR TITLE
Fixed Conversion warnings for MP3s, added quite flag

### DIFF
--- a/Utilities/consoleout.hpp
+++ b/Utilities/consoleout.hpp
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <mutex>
 
+// Forward declare global quiet mode flag
+namespace globals {extern bool quietMode;}
+
 namespace ConsoleOut {
 static constexpr const char *RED = "\033[31m";
 static constexpr const char *GREEN = "\033[32m";
@@ -27,6 +30,7 @@ inline void err(const char *msg = "") {
     }
 }
 inline void warn(const char *msg) {
+    if (::globals::quietMode) return;  // Suppress warnings in quiet mode
     std::lock_guard<std::mutex> lock(ConsoleMutex);
     if (msg[0] != '\0') {
         printf("%s[WRN]\t%s%s\n", YELLOW, RESET, msg);

--- a/Utilities/globals.hpp
+++ b/Utilities/globals.hpp
@@ -22,5 +22,6 @@ extern bool Parallel;
 extern std::size_t threads;
 extern bool recursive;
 extern bool musicbrainzConfirm;
+extern bool quietMode;
 } // namespace globals
 #endif

--- a/coreoperations.cpp
+++ b/coreoperations.cpp
@@ -1,4 +1,6 @@
 #include <cstdio>
+#include <cstdarg>
+#include <cstring>
 #include "Utilities/consoleout.hpp"
 #include "Utilities/pathutils.hpp"
 using namespace ConsoleOut;
@@ -45,6 +47,22 @@ extern "C" {
 }
 
 namespace {
+// Suppress FFmpeg's verbose logging (filters out expected MP3 timestamp warnings, etc.)
+static void SuppressFFmpegLogging(void *ptr, int level, const char *fmt, va_list vl) {
+    (void)ptr;
+    if (level <= AV_LOG_ERROR) {
+        // Check if it's an expected MP3 timestamp warning - if so, skip it
+        if (fmt && (strstr(fmt, "Could not update timestamps") != nullptr)) {
+            return;
+        }
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), fmt, vl);
+        if (buffer[0] != '\0') {
+            // ffmpeg errors are printed to stderr by default, so we just ignore them
+        }
+    }
+}
+
 std::string AvErrorToString(int errorCode) {
     char errorBuffer[AV_ERROR_MAX_STRING_SIZE] = {0};
     av_strerror(errorCode, errorBuffer, sizeof(errorBuffer));
@@ -612,6 +630,10 @@ int QualityToBitrateKbps(bitfake::type::AudioFormat format, bitfake::type::VBRQu
 
 bool ConvertWithLibAv(const fs::path &inputPath, const fs::path &outputFile, bitfake::type::AudioFormat format,
                       bitfake::type::VBRQualities quality, int opusBitrateKbps) {
+    // Suppress FFmpeg's verbose logging for timestamps and other non-critical warnings
+    av_log_set_callback(SuppressFFmpegLogging);
+    av_log_set_level(AV_LOG_FATAL);  // Only show fatal errors
+    
     AVFormatContext *inputFormat = nullptr;
     AVFormatContext *outputFormat = nullptr;
     AVCodecContext *decoderContext = nullptr;
@@ -1294,6 +1316,7 @@ bool ConvertToFileType(const fs::path &inputPath, const fs::path &outputPath, bi
         } else {
             if (!ConvertWithLibAv(sourcePath, outputFile, format, quality, gb::opusBitrateKbps)) {
                 err("Library-based conversion failed for requested output format.");
+                err(("File: " + sourcePath.string()).c_str());
                 removePartialOutput(outputFile);
                 return false;
             }

--- a/filechecks.cpp
+++ b/filechecks.cpp
@@ -113,6 +113,10 @@ bool IsSpecificAudioFormat(const fs::path &path, bitfake::type::AudioFormat form
         return (memcmp(buffer, "fLaC", 4) == 0);
     case bitfake::type::AudioFormat::OGG:
         return (memcmp(buffer, "OggS", 4) == 0);
+    case bitfake::type::AudioFormat::M4A:
+    case bitfake::type::AudioFormat::ALAC:
+        // M4A/ALAC files are MP4 containers with "ftyp" atom at offset 4
+        return (memcmp(buffer + 4, "ftyp", 4) == 0);
     // Add more cases for other formats as needed
     default:
         warn("Unsupported audio format specified for checking.");

--- a/globals.cpp
+++ b/globals.cpp
@@ -14,4 +14,5 @@ bool Parallel = true;
 std::size_t threads = 0;
 bool recursive = false;
 bool musicbrainzConfirm = true;
+bool quietMode = false;
 } // namespace globals

--- a/main.cpp
+++ b/main.cpp
@@ -72,6 +72,7 @@ int main(int argc, char *argv[]) {
                     "  -mb,   --musicbrainz                     Fetch metadata from MusicBrainz and write to file\n");
                 printf("  -mbnc, --musicbrainz-no-confirm          Bypass confirmation and write MusicBrainz metadata immediately\n");
                 printf("  -lrc,  --lrclib                          Fetch lyrics from LRCLib and write a .lrc file next to input\n");
+                printf("  -q,    --quiet                           Suppress non-critical warnings\n");
                 printf("  -v,    --version                         Show program version\n");
                 return EXIT_SUCCESS;
             }
@@ -235,6 +236,10 @@ int main(int argc, char *argv[]) {
                        "the authors be "
                        "held liable for any damages arising from the use of this software.\n");
                 return EXIT_SUCCESS;
+            }
+
+            if (strcmp(argv[i], "-q") == 0 || strcmp(argv[i], "--quiet") == 0) {
+                gb::quietMode = true;
             }
 
             if (strcmp(argv[i], "--parallel") == 0 || strcmp(argv[i], "-p") == 0) {

--- a/onlineoperations.cpp
+++ b/onlineoperations.cpp
@@ -31,6 +31,7 @@ namespace bitfake::online {
 // Helper functions to help extract metadata from a JSON/XML
 // which is expected from libcurl when we request metadata from musicbrainz
 // i do not plan on adding any other database because MB is public, and FOSS.
+// i fucking LIED!! discogs sounds sm better accouring to a few soulseek souls. we must add it soon.
 
 // example XML:
 /*


### PR DESCRIPTION
Feature add: Quiet flag 
Bug DROPPED.: mp3 spamming warnings

additional notes: errors for lib based conversion fails output file in question to pin point potential corrupted file